### PR TITLE
Fix the package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 ```bash
 # From your Backstage root directory
 cd packages/app
-yarn add @shipshapecode/plugin-graphql-voyager
+yarn add @shipshapecode/backstage-plugin-graphql-voyager
 ```
 
 
 2. Add the `GraphqlVoyagerPage` page to the routes in your app:
 
 ```tsx
-import { GraphqlVoyagerPage } from '@shipshapecode/plugin-graphql-voyager';
+import { GraphqlVoyagerPage } from '@shipshapecode/backstage-plugin-graphql-voyager';
 // down in the sidebar
     <Route path="/graphql-voyager" element={<GraphqlVoyagerPage />}/>
   </FlatRoutes>


### PR DESCRIPTION
# Motivation

I'm trying to install `@shipshapecode/backstage-plugin-graphql-voyager` by following the readme, but I'm getting an error that package is not available

```
➜  app git:(graphql-plugin) yarn add @shipshapecode/plugin-graphql-voyager
yarn add v1.22.10
[1/4] 🔍  Resolving packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/@shipshapecode%2fplugin-graphql-voyager: Not found".
info If you think this is a bug, please open a bug report with the information provided in "/Users/tarasmankovski/Repositories/backstage-demo/packages/app/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
``` 

# Approach

Fix the name of the package in the readme.