### PR TITLE
Add the ability to render the GraphQL Voyager using an SDL string

### DIFF
--- a/src/components/GraphQLVoyagerComponent/index.ts
+++ b/src/components/GraphQLVoyagerComponent/index.ts
@@ -1,1 +1,0 @@
-export { GraphQLVoyagerComponent } from './GraphQLVoyagerComponent';

--- a/src/components/GraphQLVoyagerPageComponent/GraphQLVoyagerPageComponent.test.tsx
+++ b/src/components/GraphQLVoyagerPageComponent/GraphQLVoyagerPageComponent.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { GraphQLVoyagerComponent } from './GraphQLVoyagerComponent';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { configApiRef } from '@backstage/core-plugin-api';
@@ -9,8 +8,9 @@ import {
   renderInTestApp,
   TestApiProvider
 } from '@backstage/test-utils';
+import { GraphQLVoyagerPageComponent } from './GraphQLVoyagerPageComponent';
 
-describe('GraphQLVoyagerComponent', () => {
+describe("GraphQLVoyagerPageComponent", () => {
   const server = setupServer();
   // Enable sane handlers for network requests
   setupRequestMockHandlers(server);
@@ -18,21 +18,21 @@ describe('GraphQLVoyagerComponent', () => {
   // setup mock response
   beforeEach(() => {
     server.use(
-      rest.get('/*', (_, res, ctx) => res(ctx.status(200), ctx.json({}))),
+      rest.get("/*", (_, res, ctx) => res(ctx.status(200), ctx.json({})))
     );
   });
 
-  it('should render', async () => {
+  it("should render", async () => {
     const mockConfig = new MockConfigApi({
-      graphql: { baseUrl: 'https://example.com' }
+      graphql: { baseUrl: "https://example.com" },
     });
     const rendered = await renderInTestApp(
       <TestApiProvider apis={[[configApiRef, mockConfig]]}>
-        <GraphQLVoyagerComponent />
+        <GraphQLVoyagerPageComponent />
       </TestApiProvider>
     );
     expect(
-      rendered.getByText('A visual representation of the schema.')
+      rendered.getByText("A visual representation of the schema.")
     ).toBeInTheDocument();
   });
 });

--- a/src/components/GraphQLVoyagerPageComponent/GraphQLVoyagerPageComponent.tsx
+++ b/src/components/GraphQLVoyagerPageComponent/GraphQLVoyagerPageComponent.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Header, Page } from "@backstage/core-components";
+import { Config } from "@backstage/config";
+import { configApiRef, useApi } from "@backstage/core-plugin-api";
+import { GraphQLVoyagerComponent } from "../GraphQLVoyagerComponent/GraphQLVoyagerComponent";
+
+export const GraphQLVoyagerPageComponent = () => {
+  const config: Config = useApi(configApiRef);
+  const graphqlEndpoint = config.get<{ baseUrl: string }>("graphql").baseUrl;
+
+  return (
+    <Page themeId="tool">
+      <Header
+        title="Graphql Voyager"
+        subtitle="A visual representation of the schema."
+      />
+      <GraphQLVoyagerComponent endpoint={graphqlEndpoint} />
+    </Page>
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { graphqlVoyagerPlugin, GraphqlVoyagerPage } from './plugin';
+export { GraphQLVoyagerComponent } from "./components/GraphQLVoyagerComponent/GraphQLVoyagerComponent";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,10 +14,11 @@ export const graphqlVoyagerPlugin = createPlugin({
 
 export const GraphqlVoyagerPage = graphqlVoyagerPlugin.provide(
   createRoutableExtension({
+    name: "graphql-voyager",
     component: () =>
-      import('./components/GraphQLVoyagerComponent').then(
-        (m) => m.GraphQLVoyagerComponent
-      ),
-    mountPoint: rootRouteRef
+      import(
+        "./components/GraphQLVoyagerPageComponent/GraphQLVoyagerPageComponent"
+      ).then((m) => m.GraphQLVoyagerPageComponent),
+    mountPoint: rootRouteRef,
   })
 );


### PR DESCRIPTION
# Motivation

I'm putting together a demo of our new GraphQL plugin for Backstage. I wanted to use this plugin to show the schema but I wanted to be able to pass the schema SDL as a string instead of reading it from a GraphQL endpoint.

# Approach

1. I separated reading url from config from the voyager component by creating a `GraphQLVoyagerPageComponent`.
2. Added the ability to pass SDL to `GraphQLVoyagerComponent`
3. Exported `GraphQLVoyagerComponent` from the plugin